### PR TITLE
🔧 Fix deployment: Remove admin import from API router

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -5,7 +5,7 @@ API router.
 from fastapi import APIRouter
 
 # Import all endpoints (basketball temporarily disabled for Railway deployment)
-from api.endpoints import betting_codes, predictions, fixtures, punters, bookmakers, dashboard, health, admin
+from api.endpoints import betting_codes, predictions, fixtures, punters, bookmakers, dashboard, health
 # from api.endpoints import basketball_predictions  # Temporarily disabled for Railway
 
 api_router = APIRouter()


### PR DESCRIPTION
- Removed admin module import that was causing deployment failure
- Admin endpoints were removed as data comes from Telegram bot, not manual seeding
- This fixes the ImportError preventing production deployment